### PR TITLE
Update Angular2 directives on Listview

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -244,7 +244,7 @@
         "prefix": "nslistview",
         "body": [
             "<ListView [items]=\"source\" (loaded)=\"onLoaded($event)\" (itemLoading)=\"onItemLoading($event)\" (itemTap)=\"onItemTap($event)\">",
-            "    <template #item=\"item\" #odd=\"odd\" #even=\"even\">",
+            "    <template let-item=\"item\" let-odd=\"odd\" let-even=\"even\">",
             "        $1",
             "    </template>",
             "</ListView>"


### PR DESCRIPTION
Angular RC uses let- instead of # to mark template attributes.
